### PR TITLE
Update example to use published npm package instead of local build output

### DIFF
--- a/examples/vite-ts/package.json
+++ b/examples/vite-ts/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.26.1"
+    "react-router-dom": "^6.26.1",
+    "relife-hooks": "^0.8.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/examples/vite-ts/pnpm-lock.yaml
+++ b/examples/vite-ts/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       react-router-dom:
         specifier: ^6.26.1
         version: 6.26.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      relife-hooks:
+        specifier: ^0.8.1
+        version: 0.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@types/react':
         specifier: ^18.3.3
@@ -985,6 +988,13 @@ packages:
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
+
+  relife-hooks@0.8.1:
+    resolution: {integrity: sha512-Vugjd0sJEFdAIKd0WJ8N4AIemMIk7+d7J1TLpxA0HvzqoALZH6o73ZYCK022NPCzzODk4FQ6aFmGhN6n//2/AA==}
+    engines: {node: '>=v18.18'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2058,6 +2068,11 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  relife-hooks@0.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   resolve-from@4.0.0: {}
 

--- a/examples/vite-ts/src/pages/lifeCycle/LifeCyclePage.tsx
+++ b/examples/vite-ts/src/pages/lifeCycle/LifeCyclePage.tsx
@@ -7,7 +7,7 @@ import {
   useUnmountBeforePaint,
   useUpdate,
   useUpdateBeforePaint,
-} from '../../../../../dist'
+} from 'relife-hooks'
 import Child from './ui/Child'
 import { RouteObject } from 'react-router-dom'
 

--- a/examples/vite-ts/src/pages/lifeCycle/ui/Child.tsx
+++ b/examples/vite-ts/src/pages/lifeCycle/ui/Child.tsx
@@ -1,9 +1,4 @@
-import {
-  useMount,
-  useMountBeforePaint,
-  useUnmount,
-  useUnmountBeforePaint,
-} from '../../../../../../dist'
+import { useMount, useMountBeforePaint, useUnmount, useUnmountBeforePaint } from 'relife-hooks'
 
 export default function Child() {
   useMountBeforePaint(() => {

--- a/examples/vite-ts/src/pages/message/ui/GetMessage.tsx
+++ b/examples/vite-ts/src/pages/message/ui/GetMessage.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react'
-import { use } from '../../../../../../dist'
+import { use } from 'relife-hooks'
 import { Post } from '../../../lib/model'
 import { styler } from '../../../lib/utils'
 


### PR DESCRIPTION
- Replace local build output folder path with actual npm published package
- Improve example setup by using the officially released version